### PR TITLE
fix packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include README.rst
+include CHANGES.rst
+include update_cpp.sh
+
+recursive-include crfsuite *
+recursive-include liblbfgs *
+recursive-include tests *.py


### PR DESCRIPTION
python-crfsuite didn't install from sdist before because README.rst was not included in source distribution.
