### PR TITLE
Fixing Typo in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Installation
 
 ::
 
-    pip install python-crfuite
+    pip install python-crfsuite
 
 Usage
 =====


### PR DESCRIPTION
There was a typo in the readme, in the installation instructions. 
