### PR TITLE
Small change to make crfsuite build under PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-python: 3.5
+python: 
+	- 3.5
+    - pypy
 sudo: false
 env:
 - TOXENV=py26
@@ -7,6 +9,7 @@ env:
 - TOXENV=py33
 - TOXENV=py34
 - TOXENV=py35
+- TOXENV=pypy
 install:
 - pip install tox
 - pip install -U cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
-python: 
-	- 3.5
-    - pypy
+python: pypy
 sudo: false
 env:
 - TOXENV=py26

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,14 @@ import glob
 import sys
 from setuptools import setup, Extension
 
+
+is_pypy = True
+try:
+    import __pypy__
+except ImportError:
+    is_pypy = False
+
+
 sources = ['pycrfsuite/_pycrfsuite.cpp', 'pycrfsuite/trainer_wrapper.cpp']
 
 # crfsuite
@@ -25,11 +33,23 @@ includes = [
 if sys.platform == 'win32':
     includes.append('crfsuite/win32')
 
-ext_modules = [Extension('pycrfsuite._pycrfsuite',
-    include_dirs=includes,
-    language='c++',
-    sources=sources
-)]
+if is_pypy:
+    from Cython.Build import cythonize
+    ext_modules = cythonize(Extension(
+        'pycrfsuite._pycrfsuite',
+        include_dirs=includes,
+        language='c++',
+        sources=sources,
+        extra_compile_args=['-lstdc++'],
+        extra_link_args=['-lstdc++'],
+        force=True,
+    ))
+else:
+    ext_modules = [Extension('pycrfsuite._pycrfsuite',
+                             include_dirs=includes,
+                             language='c++',
+                             sources=sources,
+                             )]
 
 setup(
     name='python-crfsuite',
@@ -53,6 +73,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: PyPy",
         "Topic :: Software Development",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Scientific/Engineering",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34
+envlist = py26,py27,py33,py34,pypy
 
 [testenv]
 changedir = {envtmpdir}


### PR DESCRIPTION
There is also a small thing needed in Cython for this to work, and
presently it appears that a Cython needs to be installed to correctly
generate a PyPy friendly version of the code.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tpeng/python-crfsuite/15)

<!-- Reviewable:end -->
