### PR TITLE
CI wheel builds

### DIFF
--- a/.manylinux-cython.sh
+++ b/.manylinux-cython.sh
@@ -2,7 +2,5 @@
 # Passes the right version of cython into update_cpp.sh for manylinux builds 
 
 shopt -s expand_aliases
-echo "${BIN}"
-echo "${PYBIN}/cython"
 alias cython="${BIN}/cython"
 source ./update_cpp.sh

--- a/.manylinux-cython.sh
+++ b/.manylinux-cython.sh
@@ -2,5 +2,7 @@
 # Passes the right version of cython into update_cpp.sh for manylinux builds 
 
 shopt -s expand_aliases
-alias cython="${PYBIN}/cython"
+echo "${BIN}"
+echo "${PYBIN}/cython"
+alias cython="${BIN}/cython"
 source ./update_cpp.sh

--- a/.manylinux-cython.sh
+++ b/.manylinux-cython.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Passes the right version of cython into update_cpp.sh for manylinux builds 
+
+shopt -s expand_aliases
+alias cython="${PYBIN}/cython"
+source ./update_cpp.sh

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -15,7 +15,6 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" install tox
         "${PYBIN}/pip" install -U cython
         export PATH="${PYBIN}:$PATH"
-        echo $PATH
         (cd /io/ && export BIN="${PYBIN}" && bash ./.manylinux-cython.sh && "${PYBIN}/tox" -e manylinux)
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -11,10 +11,9 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp35"* ]] || \
        [[ "${PYBIN}" == *"cp36"* ]]; 
     then
-        alias cython="${PYBIN}/cython"
         "${PYBIN}/pip" install -r /io/requirements-doc.txt
         "${PYBIN}/pip" install -U cython
-        (cd /io/ && bash ./update_cpp.sh)
+        (cd /io/ && bash ./manylinux_cython.sh)
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -14,7 +14,10 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" install pytest
         "${PYBIN}/pip" install -U cython
         "${PYBIN}/pip" install argparse
-        "${PYBIN}/cython" /io/pycrfsuite/_pycrfsuite.pyx --cplus -a -I pycrfsuite
+        cd /io/pycrfsuite/
+        ls
+        "${PYBIN}/cython" _pycrfsuite.pyx --cplus -a -I pycrfsuite
+        cd ../..
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -11,10 +11,10 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp35"* ]] || \
        [[ "${PYBIN}" == *"cp36"* ]]; 
     then
+        alias cython="${PYBIN}/cython"
         "${PYBIN}/pip" install -r /io/requirements-doc.txt
-        "${PYBIN}/pip" install pytest
         "${PYBIN}/pip" install -U cython
-        "${PYBIN}/cython" /io/pycrfsuite/_pycrfsuite.pyx --cplus -a -I /io/pycrfsuite
+        (cd /io/ && bash ./update_cpp.sh)
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi
@@ -36,7 +36,7 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" uninstall -y python-crfsuite
         "${PYBIN}/pip" install python-crfsuite --no-index -f /io/wheelhouse
         "${PYBIN}/pip" install tox
-        "${PYBIN}/tox"
+        (cd /io/ && "${PYBIN}/tox")
     fi
 done
 

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -14,10 +14,7 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" install pytest
         "${PYBIN}/pip" install -U cython
         "${PYBIN}/pip" install argparse
-        cd /io/pycrfsuite/
-        ls
-        "${PYBIN}/cython" _pycrfsuite.pyx --cplus -a -I pycrfsuite
-        cd ../..
+        "${PYBIN}/cython" /io/pycrfsuite/_pycrfsuite.pyx --cplus -a -I /io/pycrfsuite
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Kill the build if anything errors
+set -e -x
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    if [[ "${PYBIN}" == *"cp27"* ]] || \
+       [[ "${PYBIN}" == *"cp33"* ]] || \
+       [[ "${PYBIN}" == *"cp34"* ]] || \
+       [[ "${PYBIN}" == *"cp35"* ]]; 
+    then
+        "${PYBIN}/pip" install -r /io/requirements-doc.txt
+        "${PYBIN}/pip" install pytest
+        "${PYBIN}/pip" install -U cython
+        "${PYBIN}/pip" install argparse
+        /io/update_cpp.sh
+        "${PYBIN}/pip" install -e /io/
+        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+    fi
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/python-crfsuite*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/
+done
+
+# Install packages and test
+for PYBIN in /opt/python/*/bin; do
+    if [[ "${PYBIN}" == *"cp27"* ]] || \
+       [[ "${PYBIN}" == *"cp33"* ]] || \
+       [[ "${PYBIN}" == *"cp34"* ]] || \
+       [[ "${PYBIN}" == *"cp35"* ]];
+    then
+        "${PYBIN}/pip" uninstall -y python-crfsuite
+        "${PYBIN}/pip" install python-crfsuite --no-index -f /io/wheelhouse
+        "${PYBIN}/pytest" tests --doctest-modules
+    fi
+done
+
+# If everything works, upload wheels to PyPi
+travis=$( cat /io/.travis_tag )
+PYBIN34="/opt/python/cp35-cp35m/bin"
+if [[ $travis ]]; then
+    "${PYBIN34}/pip" install twine;
+    "${PYBIN34}/twine" upload --config-file /io/.pypirc /io/wheelhouse/python-crfsuite*.whl;
+fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -8,12 +8,12 @@ for PYBIN in /opt/python/*/bin; do
     if [[ "${PYBIN}" == *"cp27"* ]] || \
        [[ "${PYBIN}" == *"cp33"* ]] || \
        [[ "${PYBIN}" == *"cp34"* ]] || \
-       [[ "${PYBIN}" == *"cp35"* ]]; 
+       [[ "${PYBIN}" == *"cp35"* ]] || \
+       [[ "${PYBIN}" == *"cp36"* ]]; 
     then
         "${PYBIN}/pip" install -r /io/requirements-doc.txt
         "${PYBIN}/pip" install pytest
         "${PYBIN}/pip" install -U cython
-        "${PYBIN}/pip" install argparse
         "${PYBIN}/cython" /io/pycrfsuite/_pycrfsuite.pyx --cplus -a -I /io/pycrfsuite
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
@@ -30,7 +30,8 @@ for PYBIN in /opt/python/*/bin; do
     if [[ "${PYBIN}" == *"cp27"* ]] || \
        [[ "${PYBIN}" == *"cp33"* ]] || \
        [[ "${PYBIN}" == *"cp34"* ]] || \
-       [[ "${PYBIN}" == *"cp35"* ]];
+       [[ "${PYBIN}" == *"cp35"* ]] || \
+       [[ "${PYBIN}" == *"cp36"* ]];
     then
         "${PYBIN}/pip" uninstall -y python-crfsuite
         "${PYBIN}/pip" install python-crfsuite --no-index -f /io/wheelhouse

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -17,12 +17,11 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/cython" /io/pycrfsuite/_pycrfsuite.pyx --cplus -a -I /io/pycrfsuite
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
-        ls wheelhouse/
     fi
 done
 
 # Bundle external shared libraries into the wheels
-for whl in wheelhouse/python-crfsuite*.whl; do
+for whl in wheelhouse/*.whl; do
     auditwheel repair "$whl" -w /io/wheelhouse/
 done
 
@@ -44,5 +43,5 @@ travis=$( cat /io/.travis_tag )
 PYBIN34="/opt/python/cp35-cp35m/bin"
 if [[ $travis ]]; then
     "${PYBIN34}/pip" install twine;
-    "${PYBIN34}/twine" upload --config-file /io/.pypirc /io/wheelhouse/python-crfsuite*.whl;
+    "${PYBIN34}/twine" upload --config-file /io/.pypirc wheelhouse/*.whl;
 fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -34,7 +34,7 @@ for PYBIN in /opt/python/*/bin; do
     then
         "${PYBIN}/pip" uninstall -y python-crfsuite
         "${PYBIN}/pip" install python-crfsuite --no-index -f /io/wheelhouse
-        "${PYBIN}/pytest" tests --doctest-modules
+        "${PYBIN}/pytest" /io/tests --doctest-modules
     fi
 done
 
@@ -43,5 +43,5 @@ travis=$( cat /io/.travis_tag )
 PYBIN34="/opt/python/cp35-cp35m/bin"
 if [[ $travis ]]; then
     "${PYBIN34}/pip" install twine;
-    "${PYBIN34}/twine" upload --config-file /io/.pypirc wheelhouse/*.whl;
+    "${PYBIN34}/twine" upload --config-file /io/.pypirc /io/wheelhouse/*.whl;
 fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -13,7 +13,7 @@ for PYBIN in /opt/python/*/bin; do
     then
         "${PYBIN}/pip" install -r /io/requirements-doc.txt
         "${PYBIN}/pip" install -U cython
-        (cd /io/ && bash ./manylinux-cython.sh)
+        (cd /io/ && bash ./.manylinux-cython.sh)
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -13,7 +13,7 @@ for PYBIN in /opt/python/*/bin; do
     then
         "${PYBIN}/pip" install -r /io/requirements-doc.txt
         "${PYBIN}/pip" install -U cython
-        (cd /io/ && BIN="${PYBIN}" && bash ./.manylinux-cython.sh)
+        (cd /io/ && export BIN="${PYBIN}" && bash ./.manylinux-cython.sh)
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -12,8 +12,11 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp36"* ]]; 
     then
         "${PYBIN}/pip" install -r /io/requirements-doc.txt
+        "${PYBIN}/pip" install tox
         "${PYBIN}/pip" install -U cython
-        (cd /io/ && export BIN="${PYBIN}" && bash ./.manylinux-cython.sh)
+        export PATH="${PYBIN}:$PATH"
+        echo $PATH
+        (cd /io/ && export BIN="${PYBIN}" && bash ./.manylinux-cython.sh && "${PYBIN}/tox" -e manylinux)
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -13,7 +13,7 @@ for PYBIN in /opt/python/*/bin; do
     then
         "${PYBIN}/pip" install -r /io/requirements-doc.txt
         "${PYBIN}/pip" install -U cython
-        (cd /io/ && bash ./manylinux_cython.sh)
+        (cd /io/ && bash ./manylinux-cython.sh)
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -14,7 +14,7 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" install pytest
         "${PYBIN}/pip" install -U cython
         "${PYBIN}/pip" install argparse
-        /io/update_cpp.sh
+        "${PYBIN}/cython" /io/pycrfsuite/_pycrfsuite.pyx --cplus -a -I pycrfsuite
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -16,6 +16,7 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" install argparse
         "${PYBIN}/cython" /io/pycrfsuite/_pycrfsuite.pyx --cplus -a -I /io/pycrfsuite
         "${PYBIN}/pip" install -e /io/
+        ls /io/wheelhouse/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi
 done

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -25,7 +25,7 @@ for whl in wheelhouse/*.whl; do
     auditwheel repair "$whl" -w /io/wheelhouse/
 done
 
-# Install packages and test
+# Install new wheels and test
 for PYBIN in /opt/python/*/bin; do
     if [[ "${PYBIN}" == *"cp27"* ]] || \
        [[ "${PYBIN}" == *"cp33"* ]] || \

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -13,7 +13,7 @@ for PYBIN in /opt/python/*/bin; do
     then
         "${PYBIN}/pip" install -r /io/requirements-doc.txt
         "${PYBIN}/pip" install -U cython
-        (cd /io/ && bash ./.manylinux-cython.sh)
+        (cd /io/ && BIN="${PYBIN}" && bash ./.manylinux-cython.sh)
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
     fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -16,8 +16,8 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/pip" install argparse
         "${PYBIN}/cython" /io/pycrfsuite/_pycrfsuite.pyx --cplus -a -I /io/pycrfsuite
         "${PYBIN}/pip" install -e /io/
-        ls /io/wheelhouse/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        ls /io/wheelhouse/
     fi
 done
 

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -43,8 +43,8 @@ done
 
 # If everything works, upload wheels to PyPi
 travis=$( cat /io/.travis_tag )
-PYBIN34="/opt/python/cp35-cp35m/bin"
+SAMPLE_PYBIN="/opt/python/cp35-cp35m/bin"
 if [[ $travis ]]; then
-    "${PYBIN34}/pip" install twine;
-    "${PYBIN34}/twine" upload --config-file /io/.pypirc /io/wheelhouse/*.whl;
+    "${SAMPLE_PYBIN}/pip" install twine;
+    "${SAMPLE_PYBIN}/twine" upload --config-file /io/.pypirc /io/wheelhouse/*.whl;
 fi

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -35,7 +35,8 @@ for PYBIN in /opt/python/*/bin; do
     then
         "${PYBIN}/pip" uninstall -y python-crfsuite
         "${PYBIN}/pip" install python-crfsuite --no-index -f /io/wheelhouse
-        "${PYBIN}/pytest" /io/tests --doctest-modules
+        "${PYBIN}/pip" install tox
+        "${PYBIN}/tox"
     fi
 done
 

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -34,8 +34,8 @@ for PYBIN in /opt/python/*/bin; do
     then
         "${PYBIN}/pip" uninstall -y python-crfsuite
         "${PYBIN}/pip" install python-crfsuite --no-index -f /io/wheelhouse
-        "${PYBIN}/pip" install tox
-        (cd /io/ && "${PYBIN}/tox")
+        "${PYBIN}/pip" install pytest
+        "${PYBIN}/pytest" /io/tests --doctest-modules
     fi
 done
 

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -17,7 +17,7 @@ for PYBIN in /opt/python/*/bin; do
         "${PYBIN}/cython" /io/pycrfsuite/_pycrfsuite.pyx --cplus -a -I /io/pycrfsuite
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
-        ls /io/wheelhouse/
+        ls wheelhouse/
     fi
 done
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,21 @@
 language: python
 matrix:
   include:
-  - sudo: required
-    services:
-      - docker
-    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-  - sudo: required
-    services:
-      - docker
-    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
-         PRE_CMD=linux32
   - os: linux
-    python: 2.7
-    env: TOXENV=py27
-  - os: linux
-    python: 3.3
-    env: TOXENV=py33
-  - os: linux
-    python: 3.4
-    env: TOXENV=py34
+    python: 3.6
+    env: TOXENV=py36
   - os: linux
     python: 3.5
     env: TOXENV=py35
   - os: linux
-    python: 3.6
-    env: TOXENV=py36
+    python: 3.4
+    env: TOXENV=py34
+  - os: linux
+    python: 3.3
+    env: TOXENV=py33
+  - os: linux
+    python: 2.7
+    env: TOXENV=py27
   - os: osx
     language: generic
     env: 
@@ -50,6 +41,15 @@ matrix:
     env: 
       - PYTHON='2.7.12'
       - TOXENV=py27
+  - sudo: required
+    services:
+      - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+  - sudo: required
+    services:
+      - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+         PRE_CMD=linux32
 
 before_install:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,81 @@
 language: python
-python: 3.5
-sudo: false
-env:
-- TOXENV=py27
-- TOXENV=py33
-- TOXENV=py34
-- TOXENV=py35
+matrix:
+    include:
+    - os: linux
+        python: 3.5
+    - os: linux
+        python: 2.7
+    - os: osx
+        language: generic
+    - os: osx
+        language: generic
+        env: PYTHON='3.5.2'
+    - sudo: required
+        services:
+            - docker
+        env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+    - sudo: required
+        services:
+            - docker
+        env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+             PRE_CMD=linux32
+
+before_install:
+- |
+    if [[ $PYTHON && "$TRAVIS_OS_NAME" == "osx" ]]; then
+        brew update;
+        brew install openssl readline;
+        brew outdated pyenv || brew upgrade pyenv;
+        brew install pyenv-virtualenv;
+        pyenv install $PYTHON;
+        export PYENV_VERSION=$PYTHON;
+        export PATH="/Users/travis/.pyenv/shims:${PATH}";
+        pyenv-virtualenv venv;
+        source venv/bin/activate;
+        python --version;
+    fi;
+    echo [distutils]                                  > ~/.pypirc;
+    echo index-servers=pypi                          >> ~/.pypirc;
+    echo [pypi]                                      >> ~/.pypirc;
+    echo repository=https://pypi.python.org/pypi     >> ~/.pypirc;
+    echo username=kmike                              >> ~/.pypirc;
+    echo password=$PYPIPASSWORD                      >> ~/.pypirc;
+    touch .travis_tag;
+    if [[ $DOCKER_IMAGE ]]; then
+        echo $TRAVIS_TAG > .travis_tag;
+        cat ~/.pypirc > .pypirc;
+    fi;
+
 install:
-- pip install tox
-- pip install -U cython
+- |
+    if [[ $DOCKER_IMAGE ]]; then
+        docker pull $DOCKER_IMAGE &&
+        docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/.manylinux-install.sh;
+        exit;
+    else
+        pip install --upgrade pip;
+        pip install -r requirements-doc.txt
+        pip install pytest
+        pip install -U cython
+        pip install argparse
+        ./update_cpp.sh;
+        pip install -e .;
+    fi;
+
 script:
-- ./update_cpp.sh
-- tox
+- py.test tests --doctest-modules
+
+after_success:
+- pip install wheel twine 
+- if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then
+    python -W ignore setup.py bdist_wheel;
+    twine upload dist/*;
+  fi;
+- if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "linux" ]]; then
+    python -W ignore setup.py sdist;
+    twine upload dist/*;
+  fi;
+
+env:
+    global:
+        - secure: %PYPIPASSWORD=your-pypi-password

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,70 +1,70 @@
 language: python
 matrix:
-    include:
-    - os: linux
-        python: 2.7
-    - os: linux
-        python: 3.3
-    - os: linux
-        python: 3.4
-    - os: linux
-        python: 3.5
-    - os: osx
-        language: generic
-    - os: osx
-        language: generic
-        env: PYTHON='3.5.2'
-    - sudo: required
-        services:
-            - docker
-        env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-    - sudo: required
-        services:
-            - docker
-        env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
-             PRE_CMD=linux32
+  include:
+  - os: linux
+    python: 2.7
+  - os: linux
+    python: 3.3
+  - os: linux
+    python: 3.4
+  - os: linux
+    python: 3.5
+  - os: osx
+    language: generic
+  - os: osx
+    language: generic
+    env: PYTHON='3.5.2'
+  - sudo: required
+    services:
+      - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+  - sudo: required
+    services:
+      - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+         PRE_CMD=linux32
 
 before_install:
 - |
-    if [[ $PYTHON && "$TRAVIS_OS_NAME" == "osx" ]]; then
-        brew update;
-        brew install openssl readline;
-        brew outdated pyenv || brew upgrade pyenv;
-        brew install pyenv-virtualenv;
-        pyenv install $PYTHON;
-        export PYENV_VERSION=$PYTHON;
-        export PATH="/Users/travis/.pyenv/shims:${PATH}";
-        pyenv-virtualenv venv;
-        source venv/bin/activate;
-        python --version;
-    fi;
-    echo [distutils]                                  > ~/.pypirc;
-    echo index-servers=pypi                          >> ~/.pypirc;
-    echo [pypi]                                      >> ~/.pypirc;
-    echo repository=https://pypi.python.org/pypi     >> ~/.pypirc;
-    echo username=kmike                              >> ~/.pypirc;
-    echo password=$PYPIPASSWORD                      >> ~/.pypirc;
-    touch .travis_tag;
-    if [[ $DOCKER_IMAGE ]]; then
-        echo $TRAVIS_TAG > .travis_tag;
-        cat ~/.pypirc > .pypirc;
-    fi;
+  if [[ $PYTHON && "$TRAVIS_OS_NAME" == "osx" ]]; then
+    brew update;
+    brew install openssl readline;
+    brew outdated pyenv || brew upgrade pyenv;
+    brew install pyenv-virtualenv;
+    pyenv install $PYTHON;
+    export PYENV_VERSION=$PYTHON;
+    export PATH="/Users/travis/.pyenv/shims:${PATH}";
+    pyenv-virtualenv venv;
+    source venv/bin/activate;
+    python --version;
+  fi;
+  echo [distutils]                                  > ~/.pypirc;
+  echo index-servers=pypi                          >> ~/.pypirc;
+  echo [pypi]                                      >> ~/.pypirc;
+  echo repository=https://pypi.python.org/pypi     >> ~/.pypirc;
+  echo username=kmike                              >> ~/.pypirc;
+  echo password=$PYPIPASSWORD                      >> ~/.pypirc;
+  touch .travis_tag;
+  if [[ $DOCKER_IMAGE ]]; then
+    echo $TRAVIS_TAG > .travis_tag;
+    cat ~/.pypirc > .pypirc;
+  fi;
 
 install:
 - |
-    if [[ $DOCKER_IMAGE ]]; then
-        docker pull $DOCKER_IMAGE &&
-        docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/.manylinux-install.sh;
-        exit;
-    else
-        pip install --upgrade pip;
-        pip install -r requirements-doc.txt
-        pip install pytest
-        pip install -U cython
-        pip install argparse
-        ./update_cpp.sh;
-        pip install -e .;
-    fi;
+  if [[ $DOCKER_IMAGE ]]; then
+    docker pull $DOCKER_IMAGE &&
+    docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/.manylinux-install.sh;
+    exit;
+  else
+    pip install --upgrade pip;
+    pip install -r requirements-doc.txt
+    pip install pytest
+    pip install -U cython
+    pip install argparse
+    ./update_cpp.sh;
+    pip install -e .;
+  fi;
 
 script:
 - py.test tests --doctest-modules
@@ -72,14 +72,14 @@ script:
 after_success:
 - pip install wheel twine 
 - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then
-    python -W ignore setup.py bdist_wheel;
-    twine upload dist/*;
+  python -W ignore setup.py bdist_wheel;
+  twine upload dist/*;
   fi;
 - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "linux" ]]; then
-    python -W ignore setup.py sdist;
-    twine upload dist/*;
+  python -W ignore setup.py sdist;
+  twine upload dist/*;
   fi;
 
 env:
-    global:
-        - secure: %PYPIPASSWORD=your-pypi-password
+  global:
+  - secure: $PYPIPASSWORD=pypipassword

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ language: python
 matrix:
     include:
     - os: linux
-        python: 3.5
-    - os: linux
         python: 2.7
+    - os: linux
+        python: 3.3
+    - os: linux
+        python: 3.4
+    - os: linux
+        python: 3.5
     - os: osx
         language: generic
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,15 @@
 language: python
+os:
+  - linux
+  - osx
+env:
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=py35
+  - TOXENV=py36
 matrix:
   include:
-  - os: linux
-    python: 2.7
-  - os: linux
-    python: 3.3
-  - os: linux
-    python: 3.4
-  - os: linux
-    python: 3.5
-  - os: osx
-    language: generic
-    env: PYTHON='3.6.0'
-  - os: osx
-    language: generic
-    env: PYTHON='3.5.2'
-  - os: osx
-    language: generic
-    env: PYTHON='2.7.12'
   - sudo: required
     services:
       - docker
@@ -62,16 +54,14 @@ install:
     exit;
   else
     pip install --upgrade pip;
-    pip install -r requirements-doc.txt
-    pip install pytest
-    pip install -U cython
-    pip install argparse
-    ./update_cpp.sh;
-    pip install -e .;
+    pip install -r requirements-doc.txt;
+    pip install tox;
+    pip install -U cython;
   fi;
 
 script:
-- py.test tests --doctest-modules
+- ./update_cpp.sh
+- tox
 
 after_success:
 - pip install wheel twine 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,13 @@ matrix:
     python: 3.5
   - os: osx
     language: generic
+    env: PYTHON='3.6.0'
   - os: osx
     language: generic
     env: PYTHON='3.5.2'
+  - os: osx
+    language: generic
+    env: PYTHON='2.7.12'
   - sudo: required
     services:
       - docker
@@ -82,4 +86,4 @@ after_success:
 
 env:
   global:
-  - secure: $PYPIPASSWORD=pypipassword
+  - secure: PYPIPASSWORD=yourpypipassword

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: python
 matrix:
   include:
+  - sudo: required
+    services:
+      - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+  - sudo: required
+    services:
+      - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+         PRE_CMD=linux32
   - os: linux
     python: 2.7
     env: TOXENV=py27
@@ -41,15 +50,6 @@ matrix:
     env: 
       - PYTHON='2.7.12'
       - TOXENV=py27
-  - sudo: required
-    services:
-      - docker
-    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-  - sudo: required
-    services:
-      - docker
-    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
-         PRE_CMD=linux32
 
 before_install:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,46 @@
 language: python
-os:
-  - linux
-  - osx
-env:
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35
-  - TOXENV=py36
 matrix:
   include:
+  - os: linux
+    python: 2.7
+    env: TOXENV=py27
+  - os: linux
+    python: 3.3
+    env: TOXENV=py33
+  - os: linux
+    python: 3.4
+    env: TOXENV=py34
+  - os: linux
+    python: 3.5
+    env: TOXENV=py35
+  - os: linux
+    python: 3.6
+    env: TOXENV=py36
+  - os: osx
+    language: generic
+    env: 
+      - PYTHON='3.6.1'
+      - TOXENV=py36
+  - os: osx
+    language: generic
+    env:
+      - PYTHON='3.5.3'
+      - TOXENV=py35
+  - os: osx
+    language: generic
+    env:
+      - PYTHON='3.4.6'
+      - TOXENV=py34
+  - os: osx
+    language: generic
+    env:
+      - PYTHON='3.3.6'
+      - TOXENV=py33
+  - os: osx
+    language: generic
+    env: 
+      - PYTHON='2.7.12'
+      - TOXENV=py27
   - sudo: required
     services:
       - docker

--- a/tox.ini
+++ b/tox.ini
@@ -7,3 +7,10 @@ deps =
     pytest
 commands =
     py.test {toxinidir}/tests --doctest-modules {posargs}
+
+[testenv:manylinux]
+changedir = {envtmpdir}
+deps = 
+    pytest
+commands =
+    py.test {toxinidir}/tests --doctest-modules {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py33,py34,py35,py36
 
 [testenv]
 changedir = {envtmpdir}


### PR DESCRIPTION
Hey @kmike and @fgregg,

Here's the promised PR for building OS X and manylinux wheels and shipping them off to PyPi.

Some notes:

- As with Appveyor, you'll have to append your PyPi password as an encrypted variable to the bottom of .travis.yml before these wheels can deploy. The [Travis CLI](https://github.com/travis-ci/travis.rb) makes this a snap: 

```
travis encrypt PYPIPASSWORD=yourpypipassword --add env.global
```

- I got rid of the tox testing in .travis.yml because it looked like it was just there to test against different Python versions, which the expanded `include` matrix will now cover.
- We're still working on standardizing this particular deploy process, so it's not yet the most elegant piece of code. Comments, concerns, or clarifying questions are very welcome.
- I haven't actually tested the upload command (for obvious reasons) for this particular repo, so there may need to be some light debugging post-merge to get the wheels off to PyPi.

Looking forward to hearing your thoughts!