### PR TITLE
Add license file to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE.txt
 include README.rst
 include CHANGES.rst
 include update_cpp.sh


### PR DESCRIPTION
~The rationale is to include all assets directories and using exclude
rules to not include unwanted content.~

~This reproduces the same source distribution as before.~