### PR TITLE
fix up deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
 branches:
   only:
     - master
-    - /^\d\.\d+$/
+    - /^\d\.[\d.]+$/
 
 before_install:
 - |
@@ -73,7 +73,6 @@ before_install:
   echo [distutils]                                  > ~/.pypirc;
   echo index-servers=pypi                          >> ~/.pypirc;
   echo [pypi]                                      >> ~/.pypirc;
-  echo repository=https://pypi.python.org/pypi     >> ~/.pypirc;
   echo username=kmike                              >> ~/.pypirc;
   echo password=$PYPIPASSWORD                      >> ~/.pypirc;
   touch .travis_tag;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,6 @@ deploy_script:
   - echo index-servers =                             >> %USERPROFILE%\\.pypirc
   - echo     pypi                                    >> %USERPROFILE%\\.pypirc
   - echo [pypi]                                      >> %USERPROFILE%\\.pypirc
-  - echo repository=https://pypi.python.org/pypi     >> %USERPROFILE%\\.pypirc
   - echo username=kmike                              >> %USERPROFILE%\\.pypirc
   - echo password=%password%                         >> %USERPROFILE%\\.pypirc
   - set HOME=%USERPROFILE%


### PR DESCRIPTION
This fixes the issues that prevented deployments for the 0.9.3 tag

1. the regex for builds in travis did not match 0.9.3 
2. the repository url for pypi has changed