### PR TITLE
setup.py was missing license field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     long_description=open('README.rst').read(),
     author="Terry Peng, Mikhail Korobov",
     author_email="pengtaoo@gmail.com, kmike84@gmail.com",
+    license="MIT",
     url='https://github.com/scrapinghub/python-crfsuite',
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
While it has no effect on the actual license or the usability of this library, it hinders the use of tools like `pip-licenses`.