### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class build_ext_check_gcc(build_ext):
 ext_modules = [Extension('pycrfsuite._pycrfsuite',
     include_dirs=includes,
     language='c++',
-    sources=sources
+    sources=sorted(sources)
 )]
 
 


### PR DESCRIPTION
Sort input file list
so that `/usr/lib64/python2.7/site-packages/pycrfsuite/_pycrfsuite.so` in
openSUSE's `python-python-crfsuite` package builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.