### PR TITLE
Fix python version checks in install script

### DIFF
--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -9,7 +9,7 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp36"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
-       [[ "${PYBIN}" == *"cp39"* ]];
+       [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]];
     then
         "${PYBIN}/pip" install tox
@@ -32,7 +32,7 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp36"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
-       [[ "${PYBIN}" == *"cp39"* ]];
+       [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310* ]];
     then
         "${PYBIN}/pip" uninstall -y python-crfsuite


### PR DESCRIPTION
Otherwise the `then` block would only be executed for python 3.10, with all other versions being ignored.

Refs #130, #131