### PR TITLE
Add missing quote in .manylinux-install.sh

### DIFF
--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -33,7 +33,7 @@ for PYBIN in /opt/python/*/bin; do
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
-       [[ "${PYBIN}" == *"cp310* ]];
+       [[ "${PYBIN}" == *"cp310"* ]];
     then
         "${PYBIN}/pip" uninstall -y python-crfsuite
         "${PYBIN}/pip" install python-crfsuite --no-index -f /io/wheelhouse


### PR DESCRIPTION
Didn't spot this in my previous fix. Seems to have been caused by the same PR.

Refs: #131 