### PR TITLE
Add GitHub workflow for building and publishing

### DIFF
--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -1,0 +1,67 @@
+name: Build and upload to PyPI
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: "Build wheels on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: "actions/checkout@v3"
+        with:
+          submodules: true
+      - name: "Build wheels"
+        uses: "pypa/cibuildwheel@v2.3.1"
+        env:
+          CIBW_SKIP: "pp38-win_amd64"  # FIXME
+          CIBW_BEFORE_BUILD: "pip install -U cython && ./update_cpp.sh"
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install -U cython && update_cpp.sh"
+          CIBW_TEST_COMMAND: "echo Wheel installed successfully"
+      - uses: "actions/upload-artifact@v3"
+        with:
+          path: "./wheelhouse/*.whl"
+
+  make_sdist:
+    name: "Build source distribution"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+        with:
+          submodules: true
+      - name: "Install dependencies"
+        run: "python -m pip install --upgrade cython"
+      - name: "Rebuild CPP files using Cython"
+        run: "./update_cpp.sh"
+      - name: "Build source distribution"
+        run: "pipx run build --sdist"
+      - uses: "actions/upload-artifact@v3"
+        with:
+          path: "./dist/*.tar.gz"
+
+  upload_to_pypi:
+    name: "Upload to PyPI"
+    runs-on: ubuntu-latest
+    needs:
+      - build_wheels
+      - make_sdist
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: "actions/download-artifact@v3"
+        with:
+          name: artifact
+          path: dist
+      - uses: "pypa/gh-action-pypi-publish@v1.5.0"
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          print_hash: true
+          verbose: true

--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -22,7 +22,7 @@ jobs:
       - name: "Build wheels"
         uses: "pypa/cibuildwheel@v2.3.1"
         env:
-          CIBW_SKIP: "pp38-win_amd64"  # FIXME
+          CIBW_SKIP: "pp*"  # FIXME
           CIBW_BEFORE_BUILD: "pip install -U cython && ./update_cpp.sh"
           CIBW_BEFORE_BUILD_WINDOWS: "pip install -U cython && update_cpp.sh"
           CIBW_TEST_REQUIRES: "pytest"

--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -25,7 +25,8 @@ jobs:
           CIBW_SKIP: "pp38-win_amd64"  # FIXME
           CIBW_BEFORE_BUILD: "pip install -U cython && ./update_cpp.sh"
           CIBW_BEFORE_BUILD_WINDOWS: "pip install -U cython && update_cpp.sh"
-          CIBW_TEST_COMMAND: "echo Wheel installed successfully"
+          CIBW_TEST_REQUIRES: "pytest"
+          CIBW_TEST_COMMAND: "pytest {project}/tests --doctest-modules"
       - uses: "actions/upload-artifact@v3"
         with:
           path: "./wheelhouse/*.whl"

--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -62,6 +62,6 @@ jobs:
       - uses: "pypa/gh-action-pypi-publish@v1.5.0"
         with:
           user: __token__
-          password: ${{ secrets.pypi_password }}
+          password: ${{ secrets.PYPI_TOKEN }}
           print_hash: true
           verbose: true


### PR DESCRIPTION
This PR adds a simple GitHub workflow to build and publish wheels using [cibuildwheel](https://cibuildwheel.readthedocs.io/) (mostly inspired by their [example](https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml)). It's probably nowhere near perfect, but should hopefully get things started again.

Some things to (re)consider / discuss:
* Python 2.7 will not be built anymore, but considering its EOL I found this to be acceptable
* The build for PyPy 3.8 on 64bit Windows failed during cython compilation, hence it's ignored using `CIBW_SKIP` (see `FIXME` comment). If anyone wants to take a look into this, feel free.
* After building, the wheels are only installed, but not tested (see `CIBW_TEST_COMMAND`), mostly because I didn't find a quick solution on how to run `tox` from within the isolated cibuildwheel environments. Again, any help or hints on this are welcome.
* This only publishes to PyPI, but not to conda. I couldn't find any hints in the repo on how this was done previously.
* To connect the workflow to PyPI, you need to add a secret `pypi_password` containing an upload token.
* A successful run of this workflow produced [these artifacts on the PyPI testing instance](https://test.pypi.org/project/python-crfsuite/#files) (didn't test them manually, though). I hope everything needed is listed.
* I didn't remove anything yet, but if the workflow is approved, we should also remove the travisCI stuff and probably also update the badges.

Any feedback is highly appreciated! 

Refs: #130, #139, #140
