### PR TITLE
Run tests for Python 3.14 and bump cibuildwheel

### DIFF
--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Build wheels"
         uses: "pypa/cibuildwheel@v3.3.0"
         env:
-          CIBW_SKIP: "pp*"  # FIXME
+          CIBW_SKIP: "pp* cp36-* cp37-* cp38-* cp39-*"  # FIXME
           CIBW_ARCHS_LINUX: "auto aarch64"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {project}/tests --doctest-modules"

--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           platforms: arm64
       - name: "Build wheels"
-        uses: "pypa/cibuildwheel@v2.21.1"
+        uses: "pypa/cibuildwheel@v3.3.0"
         env:
           CIBW_SKIP: "pp*"  # FIXME
           CIBW_ARCHS_LINUX: "auto aarch64"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          - os: ubuntu-latest
-            python-version: "3.6"
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+0.9.12 (unreleased)
+-------------------
+
+* Dropped support for Python 3.6, 3.7, 3.8, 3.9.
+* Added support for Python 3.12, 3.13, 3.14.
+
 0.9.9 (2023-02-01)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 readme = "README.rst"
 license = {text = "MIT License", url = "http://www.opensource.org/licenses/mit-license.php"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
    "Development Status :: 4 - Beta",
    "Intended Audience :: Developers",
@@ -17,11 +17,11 @@ classifiers = [
    "Programming Language :: Cython",
    "Programming Language :: Python",
    "Programming Language :: Python :: 3",
-   "Programming Language :: Python :: 3.6",
-   "Programming Language :: Python :: 3.7",
-   "Programming Language :: Python :: 3.8",
-   "Programming Language :: Python :: 3.9",
    "Programming Language :: Python :: 3.10",
+   "Programming Language :: Python :: 3.11",
+   "Programming Language :: Python :: 3.12",
+   "Programming Language :: Python :: 3.13",
+   "Programming Language :: Python :: 3.14",
    "Topic :: Software Development",
    "Topic :: Software Development :: Libraries :: Python Modules",
    "Topic :: Scientific/Engineering",
@@ -42,6 +42,19 @@ dev = ["tox",
 [build-system]
 requires = ["setuptools>=42", "wheel", "cython"]
 build-backend = "setuptools.build_meta"
+
+
+[tool.bumpversion]
+current_version = "0.9.11"
+commit = true
+tag = true
+tag_name = "{new_version}"
+
+[[tool.bumpversion.files]]
+filename = "CHANGES.rst"
+search = "\\(unreleased\\)$"
+replace = "({now:%Y-%m-%d})"
+regex = true
 
 
 [tool.setuptools.packages.find]

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311,py312
+envlist = py39,py310,py311,py312,py313,py314
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [testenv]
 changedir = {envtmpdir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py39,py310,py311,py312,py313,py314
+envlist = py310,py311,py312,py313,py314
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
Updates the tested versions and bumps cibuildwheel for Python 3.14 wheels

I have let the github actions run on my fork and seems like everything has passed and it has py314 wheels built https://github.com/kviktor/python-crfsuite/pull/1